### PR TITLE
Update to simplify using with package manager, and associate with *.dl files

### DIFF
--- a/souffle-mode.el
+++ b/souffle-mode.el
@@ -35,4 +35,7 @@
   (setq-local comment-end "")
 )
 
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.dl\\'" . souffle-mode))
+
 (provide 'souffle-mode)

--- a/souffle-mode.el
+++ b/souffle-mode.el
@@ -25,6 +25,7 @@
         ("\\number\\|symbol" . font-lock-builtin-face)
         (":" . font-lock-constant-face)))
 
+;;;###autoload
 (define-derived-mode souffle-mode fundamental-mode "souffle"
   "major mode for editing Souffle datalog files."
   :syntax-table souffle-mode-syntax-table
@@ -34,4 +35,4 @@
   (setq-local comment-end "")
 )
 
-(provide 'souffle)
+(provide 'souffle-mode)


### PR DESCRIPTION
Having the provided feature named differently from the mode makes it a little awkward to use with some package managers in Emacs.  Also, adding autoloads and file extension associations seems more convenient.